### PR TITLE
Fix motion issues in safari

### DIFF
--- a/packages/core/src/Motion/__snapshots__/test.tsx.snap
+++ b/packages/core/src/Motion/__snapshots__/test.tsx.snap
@@ -9,7 +9,7 @@ You're switching between persisted and unpersisted, don't do this. Either always
 exports[`<Motion /> self targetted motions should throw when changing into "triggerSelfKey" after initial mount 1`] = `
 "@element-motion/core v0.0.0
 
-You're switching between self triggering modes, don't do this. Either always set the \\"triggerSelfKey\\" prop, or keep as undefined."
+You're switching between self triggering modes, don't do this. Either always set the \\"triggerSelfKey\\" prop or keep as undefined."
 `;
 
 exports[`<Motion /> self targetted motions should throw when using both "in" and "triggerSelfKey" props after initial mount 1`] = `
@@ -22,7 +22,7 @@ exports[`<Motion /> should pass dom data to child motion 1`] = `
 Array [
   Object {
     "destination": Object {
-      "element": undefined,
+      "element": <div />,
       "elementBoundingBox": Object {
         "location": Object {
           "left": 0,
@@ -40,7 +40,7 @@ Array [
       },
       "focalTargetElement": undefined,
       "focalTargetElementBoundingBox": undefined,
-      "render": undefined,
+      "render": [Function],
     },
     "origin": Object {
       "element": <div />,
@@ -71,7 +71,7 @@ exports[`<Motion /> should pass dom data to child motion when using in prop 1`] 
 Array [
   Object {
     "destination": Object {
-      "element": undefined,
+      "element": <div />,
       "elementBoundingBox": Object {
         "location": Object {
           "left": 0,
@@ -89,7 +89,7 @@ Array [
       },
       "focalTargetElement": undefined,
       "focalTargetElementBoundingBox": undefined,
-      "render": undefined,
+      "render": [Function],
     },
     "origin": Object {
       "element": <div />,

--- a/packages/core/src/Motion/test.tsx
+++ b/packages/core/src/Motion/test.tsx
@@ -81,7 +81,7 @@ describe('<Motion />', () => {
         }
         to={
           <Motion name="anim-0" onFinish={done}>
-            <div />
+            {motion => <div {...motion} />}
           </Motion>
         }
         start={false}
@@ -108,7 +108,7 @@ describe('<Motion />', () => {
         }
         to={
           <Motion name="anim-1" onFinish={deferred.resolve}>
-            <div />
+            {motion => <div {...motion} />}
           </Motion>
         }
         start={false}
@@ -138,7 +138,7 @@ describe('<Motion />', () => {
         )}
         to={
           <Motion name="anim-aa" onFinish={deferred.resolve}>
-            <div />
+            {motion => <div {...motion} />}
           </Motion>
         }
         start={false}

--- a/packages/core/src/__docs__/2-getting-started/docs.mdx
+++ b/packages/core/src/__docs__/2-getting-started/docs.mdx
@@ -319,7 +319,7 @@ and `false` when you consider it to be hidden.
         <Styled.Root>
           <Styled.ImageContainer>
             <Motion name={src} in={inn}>
-              <Move>
+              <Move zIndex={89}>
                 {({ ref, style }) => (
                   <Styled.Img
                     src={src}
@@ -355,7 +355,7 @@ and `false` when you consider it to be hidden.
               </div>
 
               <Motion name={src}>
-                <Move>
+                <Move zIndex={89} createStackingContext>
                   {({ ref, style }) => <Styled.PageImage src={src} ref={ref} style={style} />}
                 </Move>
               </Motion>

--- a/packages/core/src/lib/dom.tsx
+++ b/packages/core/src/lib/dom.tsx
@@ -1,3 +1,13 @@
+export function eventListener<K extends keyof HTMLElementEventMap>(
+  element: HTMLElement,
+  event: K,
+  cb: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
+  options?: boolean | AddEventListenerOptions | undefined
+) {
+  element.addEventListener<K>(event, cb, options);
+  return () => element.removeEventListener(event, cb, options);
+}
+
 export function getDocumentScroll() {
   const scrollTop =
     document.documentElement && document.documentElement.scrollTop

--- a/packages/core/src/motions/FadeMove/index.tsx
+++ b/packages/core/src/motions/FadeMove/index.tsx
@@ -73,7 +73,7 @@ export default class FadeMove extends React.Component<FadeMoveProps> {
         transformOrigin: '0 0',
         transform: 'translate3d(0, 0, 0) scale3d(1, 1, 1)',
         opacity: 1,
-        // Elminate any margins so they don't affect the transition.
+        // Eliminate any margins so they don't affect the transition.
         margin: 0,
         height: `${originTarget.size.height}px`,
         width: `${originTarget.size.width}px`,
@@ -87,14 +87,7 @@ export default class FadeMove extends React.Component<FadeMoveProps> {
     });
   };
 
-  beforeAnimate: MotionCallback = (data, onFinish, setChildProps) => {
-    setChildProps({
-      style: prevStyle => ({
-        ...prevStyle,
-        opacity: 0,
-      }),
-    });
-
+  beforeAnimate: MotionCallback = (data, onFinish) => {
     onFinish();
 
     return this.renderMotion(data);
@@ -103,17 +96,6 @@ export default class FadeMove extends React.Component<FadeMoveProps> {
   animate: MotionCallback = (data, onFinish) => {
     setTimeout(onFinish, this.calculatedDuration);
     return this.renderMotion(data, { moveToTarget: true });
-  };
-
-  afterAnimate: MotionCallback = (_, onFinish, setChildProps) => {
-    setChildProps({
-      style: prevStyle => ({
-        ...prevStyle,
-        opacity: 1,
-      }),
-    });
-
-    onFinish();
   };
 
   render() {
@@ -126,7 +108,6 @@ export default class FadeMove extends React.Component<FadeMoveProps> {
           payload: {
             beforeAnimate: this.beforeAnimate,
             animate: this.animate,
-            afterAnimate: this.afterAnimate,
           },
         }}
       >

--- a/packages/core/src/motions/FocalRevealMove/__docs__/docs.mdx
+++ b/packages/core/src/motions/FocalRevealMove/__docs__/docs.mdx
@@ -196,7 +196,7 @@ import Motion, { FocalRevealMove, FocalTarget } from '@element-motion/core';
 
 <Props of={FocalRevealMove} />
 
-## Caveats
+## Gotchas
 
 Reveal works by default modifying the width and height of the element,
 starting from the [FocalTarget](/focal-target) element.

--- a/packages/core/src/motions/Move/__docs__/docs.mdx
+++ b/packages/core/src/motions/Move/__docs__/docs.mdx
@@ -47,3 +47,10 @@ import { Move } from '@element-motion/core';
 ## Props
 
 <Props of={Move} />
+
+## Gotchas
+
+Noticing that your in transit element isn't being stacked correctly?
+You'll want to create a [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) by opting into `createStackingContext` which will set `position: relative` to the inflight element.
+
+This should fix your stacking problems.

--- a/packages/core/src/motions/Move/index.tsx
+++ b/packages/core/src/motions/Move/index.tsx
@@ -57,6 +57,13 @@ export interface MoveProps extends CollectorChildrenProps {
    * Defaults to true.
    */
   scaleY?: boolean;
+
+  /**
+   * Will set "position: relative" on the element during a transition.
+   * Useful for creating a stacking context to position the element where you want in the stack.
+   * Use "zIndex" prop to set the appropriate position in the stack.
+   */
+  createStackingContext?: boolean;
 }
 
 export default class Move extends React.Component<MoveProps> {
@@ -74,7 +81,15 @@ export default class Move extends React.Component<MoveProps> {
   abort = noop;
 
   beforeAnimate: MotionCallback = (data, onFinish, setChildProps) => {
-    const { zIndex, useFocalTarget, transformX, transformY, scaleX, scaleY } = this.props;
+    const {
+      zIndex,
+      useFocalTarget,
+      transformX,
+      transformY,
+      scaleX,
+      scaleY,
+      createStackingContext,
+    } = this.props;
 
     if (process.env.NODE_ENV === 'development') {
       throwIf(
@@ -102,7 +117,7 @@ export default class Move extends React.Component<MoveProps> {
       style: prevStyles => ({
         ...prevStyles,
         zIndex,
-        opacity: 1,
+        position: createStackingContext ? 'relative' : undefined,
         transformOrigin: '0 0',
         visibility: 'visible',
         willChange: combine('transform')(prevStyles.willChange),

--- a/packages/core/src/motions/ReshapingContainer/index.tsx
+++ b/packages/core/src/motions/ReshapingContainer/index.tsx
@@ -165,7 +165,14 @@ export default class ReshapingContainer extends React.PureComponent<ReshapingCon
               />
 
               {/* Position relative/zIndex needed to position this above the floating background. */}
-              {children({ style: { position: 'relative', zIndex: 2, maxHeight } })}
+              {children({
+                style: {
+                  maxHeight,
+                  zIndex: 2,
+                  // Using position: relative fucks out in Safari with clip-path resulting in clip-path not transitioning
+                  position: 'relative',
+                },
+              })}
             </ComponentAs>
           )}
         </Move>

--- a/packages/core/src/motions/Reveal/__docz__/docs.mdx
+++ b/packages/core/src/motions/Reveal/__docz__/docs.mdx
@@ -22,9 +22,16 @@ import { Reveal } from '@element-motion/core';
 
 <Props of={Reveal} />
 
-## Caveats
+## Gotchas
+
+### Collapsing margins
 
 Be careful of collapsing margins when utilising this motion,
 they will make the destination element jump around,
 probably.
 If you're seeing some odd behavior - maybe try a flex container instead.
+
+### Composing with move
+
+When composing with any motion that uses `transform` or `position: relative`,
+Reveal will not work in Safari - follow the bug here: https://bugs.webkit.org/show_bug.cgi?id=196731.

--- a/packages/core/src/motions/Reveal/index.tsx
+++ b/packages/core/src/motions/Reveal/index.tsx
@@ -57,10 +57,9 @@ export default class Reveal extends React.Component<RevealProps> {
         data.origin.elementBoundingBox
           ? {
               ...prevStyles,
+              WebkitClipPath: `inset(${topOffset}px ${right}px ${bottom}px ${leftOffset}px)`,
               clipPath: `inset(${topOffset}px ${right}px ${bottom}px ${leftOffset}px)`,
-              opacity: 1,
-              visibility: 'visible',
-              willChange: combine('clip-path')(prevStyles.willChange),
+              willChange: combine('clip-path, -webkit-clip-path')(prevStyles.willChange),
             }
           : undefined,
     });
@@ -78,10 +77,11 @@ export default class Reveal extends React.Component<RevealProps> {
     setChildProps({
       style: prevStyles => ({
         ...prevStyles,
+        WebkitClipPath: 'inset(0px)',
         clipPath: 'inset(0px)',
-        transition: combine(`clip-path ${calculatedDuration}ms ${timingFunction}`)(
-          prevStyles.transition
-        ),
+        transition: combine(
+          `-webkit-clip-path ${calculatedDuration}ms ${timingFunction}, clip-path ${calculatedDuration}ms ${timingFunction}`
+        )(prevStyles.transition),
       }),
     });
 

--- a/packages/core/src/motions/RevealReshapingContainer/__docz__/docs.mdx
+++ b/packages/core/src/motions/RevealReshapingContainer/__docz__/docs.mdx
@@ -118,7 +118,7 @@ import { ReshapingContainer } from '@element-motion/core';
 
 <Props of={ReshapingContainer} />
 
-## Caveats
+## Gotchas
 
 Be careful of collapsing margins when utilising this motion,
 they will make the destination element jump around when revealing,

--- a/packages/core/src/motions/RevealReshapingContainer/index.tsx
+++ b/packages/core/src/motions/RevealReshapingContainer/index.tsx
@@ -66,6 +66,7 @@ export default class RevealReshapingContainer extends React.PureComponent<
   render() {
     const { children, duration, timingFunction, triggerKey } = this.props;
 
+    // The Move transition using transform fucks out in Safari with clip-path resulting in clip-path not transitioning
     return (
       <ReshapingContainer {...this.props}>
         {reshaping => (


### PR DESCRIPTION
## Needs fixing

- [x] flash of unrendered content
- [x] reveal not being animated by itself
- [x] composed motions seemingly not starting at the same time
- [x] move stacking being off on capitals search example
- [x] move not animating at times on on capitals search example (getting `Infinity` for one of the values, height is returning 0)
- [x] waiting for image causing flicker

## Moving out
- [x] reveal not being animated when composed with reshaping container/move (aka clip-path not working with transition/position: relative) [will extract to another issue]

## Tested over

- [x] safari 12.1.1
- [x] firefox 67
- [x] chrome 74
- [ ] edge