### PR TITLE
Scale motion

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,9 +20,10 @@
     "react/sort-comp": "off",
     "react/destructuring-assignment": "never",
     "import/prefer-default-export": "off",
+    "no-restricted-properties": "off",
     "import/no-extraneous-dependencies": [
       "error",
-      { "devDependencies": ["**/*test.tsx", "**/*stories.tsx"] }
+      { "devDependencies": ["**/*test.tsx", "**/*stories.tsx", "**/__docs__/**"] }
     ]
   }
 }

--- a/packages/core/.size-limit.js
+++ b/packages/core/.size-limit.js
@@ -1,10 +1,10 @@
 module.exports = [
   {
-    limit: '7 KB',
+    limit: '8 KB',
     path: 'dist/esm/packages/core/src/index.js',
   },
   {
-    limit: '2.7 KB',
+    limit: '2.72 KB',
     path: 'dist/esm/packages/core/src/Motion/index.js',
   },
   {

--- a/packages/core/src/Motion/__snapshots__/test.tsx.snap
+++ b/packages/core/src/Motion/__snapshots__/test.tsx.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Motion /> persisted motions should throw when changing into "in" after initial mount 1`] = `
-"@element-motion/core v0.0.0
+"@element-motion
 
 You're switching between persisted and unpersisted, don't do this. Either always set the \\"in\\" prop as true or false, or keep as undefined."
 `;
 
 exports[`<Motion /> self targetted motions should throw when changing into "triggerSelfKey" after initial mount 1`] = `
-"@element-motion/core v0.0.0
+"@element-motion
 
 You're switching between self triggering modes, don't do this. Either always set the \\"triggerSelfKey\\" prop or keep as undefined."
 `;
 
 exports[`<Motion /> self targetted motions should throw when using both "in" and "triggerSelfKey" props after initial mount 1`] = `
-"@element-motion/core v0.0.0
+"@element-motion
 
 Don't use \\"in\\" and \\"triggerSelfKey\\" together. If your element is persisted use \\"in\\". If your element is targeting itself for motions use \\"triggerSelfKey\\"."
 `;
@@ -22,7 +22,9 @@ exports[`<Motion /> should pass dom data to child motion 1`] = `
 Array [
   Object {
     "destination": Object {
-      "element": <div />,
+      "element": <div
+        style=""
+      />,
       "elementBoundingBox": Object {
         "location": Object {
           "left": 0,
@@ -71,7 +73,9 @@ exports[`<Motion /> should pass dom data to child motion when using in prop 1`] 
 Array [
   Object {
     "destination": Object {
-      "element": <div />,
+      "element": <div
+        style=""
+      />,
       "elementBoundingBox": Object {
         "location": Object {
           "left": 0,

--- a/packages/core/src/Motion/index.tsx
+++ b/packages/core/src/Motion/index.tsx
@@ -234,6 +234,21 @@ If it's an image, try and have the image loaded before mounting or set a static 
       const { collectorData, elementData } = DOMSnapshot;
       this.executing = true;
 
+      /**
+       * !! START SAFARI BULLSHIT HACK ALERT !!
+       * Safari has a problem correctly updating a parent element if a child element changes its position.
+       * Because of this it will read the wrong dimensions in this frame and then in the next frame have them
+       * as we expected.
+       *
+       * This essentially forces the browser to repaint everything in the current frame.
+       */
+      this.element!.style.display = 'none';
+      this.element!.offsetHeight; // eslint-disable-line no-unused-expressions
+      this.element!.style.display = '';
+      /**
+       * !! END SAFARI BULLSHIT HACK ALERT !!
+       */
+
       // Calculate DOM data for the executing element to then be passed to the motion/s.
       const motionData: MotionData = {
         origin: elementData,

--- a/packages/core/src/Motion/test.tsx
+++ b/packages/core/src/Motion/test.tsx
@@ -8,10 +8,6 @@ import defer from '../lib/defer';
 import * as store from '../lib/store';
 import * as utils from '../__tests__/utils';
 
-jest.mock('../../package.json', () => ({
-  version: '0.0.0',
-  name: '@element-motion/core',
-}));
 jest.mock('../lib/dom');
 window.requestAnimationFrame = (cb: Function) => cb();
 
@@ -42,7 +38,7 @@ describe('<Motion />', () => {
 
     mount(<Motion>{props => <div {...props} />}</Motion>);
 
-    expect(console.warn).toHaveBeenCalledWith(`@element-motion/core v0.0.0
+    expect(console.warn).toHaveBeenCalledWith(`@element-motion
 
 "name" prop needs to be defined. Without it you may have problems matching up motion targets. You will not get this error when using "triggerSelfKey" prop.`);
   });

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -25,6 +25,8 @@ export { WrappedVisibilityManager as MotionManager } from './VisibilityManager';
 export * from './Collector';
 export { default as Collector } from './Collector';
 export { default as FocalTarget } from './FocalTarget';
+export { default as Scale } from '../../motions/src/Scale';
+export { default as InverseScale } from '../../motions/src/Scale/InverseScale';
 export * from './lib/curves';
 export * from './lib/dom';
 export * from './lib/math';

--- a/packages/core/src/lib/curves.tsx
+++ b/packages/core/src/lib/curves.tsx
@@ -1,8 +1,62 @@
+import { throwIf } from './log';
 
 export const standard = () => 'cubic-bezier(0.4, 0.0, 0.2, 1)';
 
-
 export const accelerate = () => 'cubic-bezier(0.4, 0.0, 1, 1)';
 
-
 export const decelerate = () => 'cubic-bezier(0.0, 0.0, 0.2, 1)';
+
+const extractBezier = (curve: string): number[] => {
+  throwIf(
+    curve.indexOf('cubic-bezier') === -1,
+    `Expected CSS3 bezier curve e.g. "cubic-bezier(0.4, 0.0, 1, 1)"`
+  );
+
+  const matches = curve.match(/\d?\.?\d/g);
+  if (matches) {
+    return matches.map(Number);
+  }
+
+  return [];
+};
+
+export const bezierToFunc = (curve: string, duration: number) => {
+  const [x1, y1, x2, y2] = extractBezier(curve);
+  const epsilon = 1000 / 60 / duration / 4;
+
+  const curveX = (t: number): number => {
+    const v = 1 - t;
+    return 3 * v * v * t * x1 + 3 * v * t * t * x2 + t * t * t;
+  };
+
+  const curveY = (t: number): number => {
+    const v = 1 - t;
+    return 3 * v * v * t * y1 + 3 * v * t * t * y2 + t * t * t;
+  };
+
+  return (t: number): number => {
+    const x = t;
+    let t0 = 0;
+    let t1 = 1;
+    let t2 = x;
+    let x3 = 0;
+
+    while (t0 < t1) {
+      x3 = curveX(t2);
+      if (Math.abs(x3 - x) < epsilon) {
+        return curveY(t2);
+      }
+
+      if (x > x3) {
+        t0 = t2;
+      } else {
+        t1 = t2;
+      }
+
+      t2 = (t1 - t0) * 0.5 + t0;
+    }
+
+    // Failure
+    return curveY(t2);
+  };
+};

--- a/packages/core/src/lib/log.tsx
+++ b/packages/core/src/lib/log.tsx
@@ -1,15 +1,13 @@
-import { name, version } from '../../package.json';
-
 export const throwIf = (check: any, message: string) => {
   if (check) {
-    throw new Error(`${name} v${version}
+    throw new Error(`@element-motion
 
 ${message}`);
   }
 };
 
 export const warn = (message: string) => {
-  console.warn(`${name} v${version}
+  console.warn(`@element-motion
 
 ${message}`);
 };

--- a/packages/core/src/lib/math.tsx
+++ b/packages/core/src/lib/math.tsx
@@ -1,23 +1,15 @@
-
 export interface Dimensions {
   width: number;
   height: number;
 }
 
-
 export function calculateHypotenuse({ width, height }: Dimensions) {
   const x2 = width ** 2;
   const y2 = height ** 2;
-
   const hypotenuse = Math.sqrt(x2 + y2);
+
   return Math.ceil(hypotenuse);
 }
-
-
-export function percentageDifference(from: number, to: number) {
-  return from / to;
-}
-
 
 export function clamp(num: number, min: number, max: number) {
   // eslint-disable-next-line no-nested-ternary

--- a/packages/core/src/lib/style.tsx
+++ b/packages/core/src/lib/style.tsx
@@ -1,9 +1,10 @@
-export const combine = (t1: string = '', delimeter = ',') => (t2?: string | number) => {
-  if (t2) {
-    return `${t1}${delimeter} ${t2}`;
+export const combine = (newValue: string = '', delimeter = ',') => (
+  prevValue?: string | number
+) => {
+  if (prevValue) {
+    return `${newValue}${delimeter} ${prevValue}`;
   }
-
-  return t1;
+  return newValue;
 };
 
 export const zIndexStack = {

--- a/packages/core/src/lib/stylesheet.tsx
+++ b/packages/core/src/lib/stylesheet.tsx
@@ -1,0 +1,17 @@
+export const createManager = () => {
+  const sheets: HTMLStyleElement[] = [];
+
+  return {
+    css: (sheet: string, className?: string) => {
+      const element = document.createElement('style');
+      element.innerText = sheet;
+      sheets.push(element);
+      document.head.appendChild(element);
+      return className;
+    },
+    removeAll: () => {
+      sheets.forEach(sheet => document.head.removeChild(sheet));
+      sheets.length = 0;
+    },
+  };
+};

--- a/packages/core/src/lib/types.tsx
+++ b/packages/core/src/lib/types.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
 
+export interface Point {
+  x: number;
+  y: number;
+}
+
 export type Omit<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
 
 export type ExtractProps<TComponentOrTProps> = TComponentOrTProps extends React.ComponentType<

--- a/packages/dev/src/colors.tsx
+++ b/packages/dev/src/colors.tsx
@@ -1,0 +1,3 @@
+export default {
+  red: '#dc143c',
+};

--- a/packages/dev/src/index.tsx
+++ b/packages/dev/src/index.tsx
@@ -4,3 +4,4 @@ export { default as SmallViewport } from './SmallViewport';
 export { default as StickyButton } from './StickyButton';
 export { default as Toggler } from './Toggler';
 export { createMoveExamples } from './createMoveExamples';
+export { default as colors } from './colors';

--- a/packages/motions/.size-limit.js
+++ b/packages/motions/.size-limit.js
@@ -36,7 +36,7 @@ module.exports = [
     path: '../core/dist/esm/packages/motions/src/Noop/index.js',
   },
   {
-    limit: '4 KB',
+    limit: '4.1 KB',
     path: '../core/dist/esm/packages/motions/src/ReshapingContainer/index.js',
     ignore: ['react', 'react-dom'],
   },
@@ -45,12 +45,20 @@ module.exports = [
     path: '../core/dist/esm/packages/motions/src/Reveal/index.js',
   },
   {
-    limit: '4.58 KB',
+    limit: '4.60 KB',
     path: '../core/dist/esm/packages/motions/src/RevealReshapingContainer/index.js',
     ignore: ['react', 'react-dom'],
   },
   {
     limit: '1.24 KB',
     path: '../core/dist/esm/packages/motions/src/Swipe/index.js',
+  },
+  {
+    limit: '1.75 KB',
+    path: '../core/dist/esm/packages/motions/src/Scale/index.js',
+  },
+  {
+    limit: '145 B',
+    path: '../core/dist/esm/packages/motions/src/Scale/InverseScale.js',
   },
 ];

--- a/packages/motions/src/Move/index.tsx
+++ b/packages/motions/src/Move/index.tsx
@@ -118,7 +118,7 @@ export default class Move extends React.Component<MoveProps> {
         ...prevStyles,
         zIndex,
         position: createStackingContext ? 'relative' : undefined,
-        transformOrigin: '0 0',
+        transformOrigin: 'top left',
         visibility: 'visible',
         willChange: combine('transform')(prevStyles.willChange),
         transform: combine(prevStyles.transform, '')(

--- a/packages/motions/src/Scale/InverseScale.tsx
+++ b/packages/motions/src/Scale/InverseScale.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { INVERSE_SCALE_CLASS_NAME } from './index';
+
+interface InverseScaleProps {
+  children: (opts: { className: string }) => React.ReactElement;
+}
+
+const InverseScale: React.FC<InverseScaleProps> = (props: InverseScaleProps) =>
+  props.children({ className: INVERSE_SCALE_CLASS_NAME });
+
+export default InverseScale;

--- a/packages/motions/src/Scale/__docs__/docs.mdx
+++ b/packages/motions/src/Scale/__docs__/docs.mdx
@@ -1,0 +1,118 @@
+---
+name: Scale
+route: /scale
+menu: Focal motions
+---
+
+import { Playground, Props } from 'docz';
+import * as Common from '@element-motion/dev';
+import Motion from '../../../../core/src/Motion';
+import Scale from '../index';
+import InverseScale from '../InverseScale';
+import Move from '../../Move';
+import * as Styled from './styled';
+
+# Scale
+
+Will scale an element from the `origin` to `destination` size.
+Can also use `InverseScale` component to counteract the transform which enables really powerful motions.
+
+## Usage
+
+```js
+import Motion, { Scale, InverseScale } from '@element-motion/core';
+```
+
+**Try the interactive demos** 👇
+
+### Without inverse scale
+
+In this example the children isn't using the `InverseScale` component - note that it looks stank.
+
+<Playground>
+  <Styled.Container>
+    <Common.Toggler>
+      {toggler => (
+        <Motion triggerSelfKey={toggler.shown}>
+          <Scale>
+            {motion => (
+              <Styled.Root {...motion} big={toggler.shown} onClick={toggler.toggle}>
+                <Styled.Text>hello, world</Styled.Text>
+              </Styled.Root>
+            )}
+          </Scale>
+        </Motion>
+      )}
+    </Common.Toggler>
+  </Styled.Container>
+</Playground>
+
+### With inverse scale
+
+Utilising the `InverseScale` component we now get a scale transform that looks _good_.
+
+<Playground>
+  <Styled.Container>
+    <Common.Toggler>
+      {toggler => (
+        <Motion triggerSelfKey={toggler.shown}>
+          <Scale>
+            {motion => (
+              <Styled.Root {...motion} big={toggler.shown} onClick={toggler.toggle}>
+                <InverseScale>
+                  {inverse => <Styled.Text {...inverse}>hello, world</Styled.Text>}
+                </InverseScale>
+              </Styled.Root>
+            )}
+          </Scale>
+        </Motion>
+      )}
+    </Common.Toggler>
+  </Styled.Container>
+</Playground>
+
+### Actual example
+
+Abusing this behaviour we can make pretty cool stuff!
+Like for example a expand/collapse component.
+
+<Playground>
+  <Styled.Container>
+    <Common.Toggler>
+      {toggler => (
+        <Motion triggerSelfKey={toggler.shown}>
+          <Scale duration={200}>
+            {motion => (
+              <Styled.Menu {...motion} isExpanded={toggler.shown} overflow="hidden">
+                <InverseScale>
+                  {inverse => (
+                    <div {...inverse}>
+                      <Styled.MenuButton onClick={toggler.toggle}>Menu</Styled.MenuButton>
+                      <Styled.MenuItems style={{ position: toggler.shown ? 'static' : 'absolute' }}>
+                        <Styled.MenuItem>Menu item 1</Styled.MenuItem>
+                        <Styled.MenuItem>Menu item 2</Styled.MenuItem>
+                        <Styled.MenuItem>Menu item 3</Styled.MenuItem>
+                        <Styled.MenuItem>Menu item 4</Styled.MenuItem>
+                      </Styled.MenuItems>
+                    </div>
+                  )}
+                </InverseScale>
+              </Styled.Menu>
+            )}
+          </Scale>
+        </Motion>
+      )}
+    </Common.Toggler>
+  </Styled.Container>
+</Playground>
+
+## Props
+
+<Props of={Scale} />
+
+## Gotchas
+
+### Inverse scale
+
+Make sure to utilise an element that is a block - either `block`, `inline-block`, `flex`, `inline-flex`.
+Else the transforms will not be applied.

--- a/packages/motions/src/Scale/__docs__/styled.tsx
+++ b/packages/motions/src/Scale/__docs__/styled.tsx
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+import { colors } from '@element-motion/dev';
+
+export const Container = styled.div`
+  height: 250px;
+`;
+
+export const Text = styled.div`
+  padding: 16px;
+  color: white;
+`;
+
+export const Root = styled.div<{ big: boolean }>`
+  background-color: ${colors.red};
+  width: ${props => (props.big ? '100%' : '150px')};
+  height: ${props => (props.big ? '100%' : '150px')};
+  cursor: pointer;
+`;
+
+export const Menu = styled.div<any>`
+  display: inline-block;
+  flex-direction: column;
+  background-color: #393939;
+  border-radius: ${props => (props.isExpanded ? 3 : 1)}px;
+  color: #fff;
+  box-shadow: 0 1px 5px rgba(32, 33, 36, 0.5);
+  position: relative;
+  overflow: ${props => props.overflow};
+`;
+
+export const MenuItems = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style: none;
+`;
+
+export const MenuButton = styled.div`
+  padding: 8px;
+  cursor: pointer;
+
+  :hover {
+    text-decoration: underline;
+  }
+`;
+
+export const MenuItem = styled.li`
+  border-top: 1px solid rgba(255, 255, 255, 0.4);
+  display: block;
+  padding: 8px;
+  white-space: nowrap;
+`;

--- a/packages/motions/src/Scale/index.tsx
+++ b/packages/motions/src/Scale/index.tsx
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import { css, keyframes, cx } from 'emotion';
+import { dynamic } from '../../../core/src/lib/duration';
+import { bezierToFunc, standard } from '../../../core/src/lib/curves';
+import { combine } from '../../../core/src/lib/style';
+import { Duration } from '../types';
+import Collector, {
+  CollectorChildrenProps,
+  CollectorActions,
+  MotionData,
+} from '../../../core/src/Collector';
+
+export interface ScaleProps extends CollectorChildrenProps {
+  timingFunction?: string;
+  duration?: Duration;
+}
+
+const buildKeyframes = (elements: MotionData, duration: number, bezierCurve: string) => {
+  const frameTime = 1000 / 60;
+  const nFrames = Math.round(duration / frameTime);
+  const percentIncrement = 100 / nFrames;
+  const originBoundingBox = elements.origin.elementBoundingBox;
+  const destinationBoundingBox = elements.destination.elementBoundingBox;
+  const startX = originBoundingBox.size.width / destinationBoundingBox.size.width;
+  const startY = originBoundingBox.size.height / destinationBoundingBox.size.height;
+  const timingFunction = bezierToFunc(bezierCurve, duration);
+  const outerAnimation: string[] = [];
+  const innerAnimation: string[] = [];
+
+  for (let i = 0; i <= nFrames; i += 1) {
+    const step = Number(timingFunction(i / nFrames).toFixed(5));
+    const percentage = Number((i * percentIncrement).toFixed(5));
+    const endX = 1;
+    const endY = 1;
+    const xScale = Number((startX + (endX - startX) * step).toFixed(5));
+    const yScale = Number((startY + (endY - startY) * step).toFixed(5));
+    const invScaleX = (1 / xScale).toFixed(5);
+    const invScaleY = (1 / yScale).toFixed(5);
+
+    outerAnimation.push(`
+      ${percentage}% {
+        transform: scale(${xScale}, ${yScale});
+      }`);
+
+    innerAnimation.push(`
+      ${percentage}% {
+        transform: scale(${invScaleX}, ${invScaleY});
+      }`);
+  }
+
+  return {
+    outer: keyframes(outerAnimation),
+    inner: keyframes(innerAnimation),
+  };
+};
+
+export const INVERSE_SCALE_CLASS_NAME = 'inVRsE-sCle';
+
+const Scale: React.FC<ScaleProps> = ({
+  children,
+  duration = 'dynamic',
+  timingFunction = standard(),
+}: ScaleProps) => {
+  let calculatedDuration: number;
+  let outerKeyframes: string;
+  let innerKeyframes: string;
+
+  return (
+    <Collector
+      data={{
+        action: CollectorActions.motion,
+        payload: {
+          beforeAnimate: (elements, onFinish, setChildProps) => {
+            const originBoundingBox = elements.origin.elementBoundingBox;
+            const destinationBoundingBox = elements.destination.elementBoundingBox;
+            const scaleToX = originBoundingBox.size.width / destinationBoundingBox.size.width;
+            const scaleToY = originBoundingBox.size.height / destinationBoundingBox.size.height;
+            const inverseScaleToX = 1 / scaleToX;
+            const inverseScaleToY = 1 / scaleToY;
+            calculatedDuration =
+              duration === 'dynamic'
+                ? dynamic(
+                    elements.origin.elementBoundingBox,
+                    elements.destination.elementBoundingBox
+                  )
+                : duration;
+
+            ({ outer: outerKeyframes, inner: innerKeyframes } = buildKeyframes(
+              elements,
+              calculatedDuration,
+              timingFunction
+            ));
+
+            const common = {
+              willChange: 'transform',
+              transformOrigin: 'top left',
+              animationTimingFunction: 'step-end',
+              animationFillMode: 'forwards',
+              animationPlayState: 'paused',
+            };
+
+            setChildProps({
+              style: prevStyle => ({
+                ...prevStyle,
+                ...common,
+                transform: combine(`scale3d(${scaleToX}, ${scaleToY}, 1)`)(prevStyle.transform),
+                animationDuration: `${calculatedDuration}ms`,
+                animationName: combine(outerKeyframes)(prevStyle.animationName),
+              }),
+              className: () =>
+                css({
+                  [`.${INVERSE_SCALE_CLASS_NAME}`]: {
+                    ...common,
+                    transform: `scale3d(${inverseScaleToX}, ${inverseScaleToY}, 1)`,
+                    animationDuration: `${calculatedDuration}ms`,
+                    animationName: `${innerKeyframes}`,
+                  },
+                }),
+            });
+
+            onFinish();
+          },
+          animate: (_, onFinish, setChildProps) => {
+            setChildProps({
+              style: prevStyle => ({
+                ...prevStyle,
+                animationPlayState: 'running',
+              }),
+              className: prevClassName =>
+                cx(
+                  prevClassName,
+                  css({
+                    [`.${INVERSE_SCALE_CLASS_NAME}`]: {
+                      animationPlayState: 'running',
+                    },
+                  })
+                ),
+            });
+
+            setTimeout(onFinish, calculatedDuration);
+          },
+        },
+      }}
+    >
+      {children}
+    </Collector>
+  );
+};
+
+export default Scale;

--- a/packages/motions/src/Scale/stories.tsx
+++ b/packages/motions/src/Scale/stories.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import styled from 'styled-components';
+import { Toggler } from '@element-motion/dev';
+import Motion from '../../../core/src/Motion';
+import Scale from './index';
+import InverseScale from './InverseScale';
+
+/**
+ * Very important
+ * Do not put padding or margin in this else it will be scaled down.
+ * It won't look correct at all.
+ */
+const Menu = styled.div<any>`
+  display: inline-block;
+  flex-direction: column;
+  background-color: #393939;
+  border-radius: ${props => (props.isExpanded ? 3 : 1)}px;
+  color: #fff;
+  box-shadow: 0 1px 5px rgba(32, 33, 36, 0.5);
+  position: relative;
+  overflow: ${props => props.overflow};
+`;
+
+const MenuItems = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style: none;
+`;
+
+const MenuButton = styled.div`
+  padding: 8px;
+  cursor: pointer;
+
+  :hover {
+    text-decoration: underline;
+  }
+`;
+
+const MenuItem = styled.li`
+  border-top: 1px solid rgba(255, 255, 255, 0.4);
+  display: block;
+  padding: 8px;
+  white-space: nowrap;
+`;
+
+storiesOf('@element-motion/core/Scale', module).add('Default', () => (
+  <Toggler>
+    {toggler => (
+      <Motion triggerSelfKey={toggler.shown}>
+        <Scale duration={200}>
+          {motion => (
+            <Menu {...motion} isExpanded={toggler.shown} overflow="hidden">
+              <InverseScale>
+                {inverse => (
+                  <div {...inverse}>
+                    <MenuButton onClick={toggler.toggle}>Menu</MenuButton>
+                    <MenuItems
+                      className="target"
+                      style={{ position: toggler.shown ? 'static' : 'absolute' }}
+                    >
+                      <MenuItem>Menu item 1</MenuItem>
+                      <MenuItem>Menu item 2</MenuItem>
+                      <MenuItem>Menu item 3</MenuItem>
+                      <MenuItem>Menu item 4</MenuItem>
+                    </MenuItems>
+                  </div>
+                )}
+              </InverseScale>
+            </Menu>
+          )}
+        </Scale>
+      </Motion>
+    )}
+  </Toggler>
+));


### PR DESCRIPTION
![scale-only](https://user-images.githubusercontent.com/6801309/59848710-2e79c880-93a9-11e9-96ca-1e9846773985.gif)

## Adds
- Dynamic timing functions created from CSS3 bezier curves
- Scale (and inverse scale) motion
- Simple stylesheet support (to replace `emotion`)

## TODO in follow up PR
- [ ] Transform motion using CSS animation
- [ ] Enable disabling specific axis scale on Scale motion
- [ ] InverseTransform helper
- [ ] Re-write Move motion composing Scale and Transform motions
- [ ] Re-write Reveal motions using new Move motion
- [ ] Replace emotion usage