### PR TITLE
Introduce keyframes into internal motion API

### DIFF
--- a/packages/core/.size-limit.js
+++ b/packages/core/.size-limit.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
-    limit: '8 KB',
+    limit: '8.25 KB',
     path: 'dist/esm/index.js',
     ignore: ['react', 'react-dom', 'emotion'],
   },

--- a/packages/motions/.size-limit.js
+++ b/packages/motions/.size-limit.js
@@ -39,7 +39,8 @@ module.exports = [
     path: 'dist/esm/Noop/index.js',
   },
   {
-    limit: '4.1 KB',
+    // Will increase in size if Motion component increases in size.
+    limit: '4.44 KB',
     path: 'dist/esm/ReshapingContainer/index.js',
     ignore: ['react', 'react-dom'],
   },
@@ -48,7 +49,8 @@ module.exports = [
     path: 'dist/esm/Reveal/index.js',
   },
   {
-    limit: '4.69 KB',
+    // Will increase in size if Motion component increases in size.
+    limit: '5.02 KB',
     path: 'dist/esm/RevealReshapingContainer/index.js',
     ignore: ['react', 'react-dom'],
   },
@@ -57,7 +59,7 @@ module.exports = [
     path: 'dist/esm/Swipe/index.js',
   },
   {
-    limit: '1.75 KB',
+    limit: '1.85 KB',
     path: 'dist/esm/Scale/index.js',
     ignore: ['emotion'],
   },
@@ -67,12 +69,12 @@ module.exports = [
     ignore: ['emotion'],
   },
   {
-    limit: '1.87 KB',
+    limit: '1.96 KB',
     path: 'dist/esm/Translate/index.js',
     ignore: ['emotion'],
   },
   {
-    limit: '118 B',
+    limit: '120 B',
     path: 'dist/esm/Translate/InverseTranslate.js',
     ignore: ['emotion'],
   },

--- a/packages/motions/src/CircleShrink/stories.tsx
+++ b/packages/motions/src/CircleShrink/stories.tsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import BodyClassName from 'react-body-classname';
+// @ts-ignore
+import * as BodyClassName from 'react-body-classname';
 import { Toggler, colors } from '@element-motion/dev';
 import { Motion } from '@element-motion/utils';
 import CircleShrink from './index';

--- a/packages/motions/src/Scale/index.tsx
+++ b/packages/motions/src/Scale/index.tsx
@@ -1,58 +1,23 @@
 import * as React from 'react';
-import { css, keyframes, cx } from 'emotion';
+import { css, cx } from 'emotion';
 import {
   Collector,
   CollectorChildrenProps,
   CollectorActions,
-  MotionData,
-  bezierToFunc,
   combine,
   standard,
   dynamic,
+  keyframes as buildKeyframes,
+  composeKeyframes,
 } from '@element-motion/utils';
 import { MotionProps } from '../types';
 
-export interface ScaleProps extends CollectorChildrenProps, MotionProps {}
-
-const buildKeyframes = (elements: MotionData, duration: number, bezierCurve: string) => {
-  const frameTime = 1000 / 60;
-  const nFrames = Math.round(duration / frameTime);
-  const percentIncrement = 100 / nFrames;
-  const originBoundingBox = elements.origin.elementBoundingBox;
-  const destinationBoundingBox = elements.destination.elementBoundingBox;
-  const timingFunction = bezierToFunc(bezierCurve, duration);
-
-  const startX = originBoundingBox.size.width / destinationBoundingBox.size.width;
-  const startY = originBoundingBox.size.height / destinationBoundingBox.size.height;
-  const endX = 1;
-  const endY = 1;
-  const animation: string[] = [];
-  const inverseAnimation: string[] = [];
-
-  for (let i = 0; i <= nFrames; i += 1) {
-    const step = Number(timingFunction(i / nFrames).toFixed(5));
-    const percentage = Number((i * percentIncrement).toFixed(5));
-    const xScale = Number((startX + (endX - startX) * step).toFixed(5));
-    const yScale = Number((startY + (endY - startY) * step).toFixed(5));
-    const invScaleX = (1 / xScale).toFixed(5);
-    const invScaleY = (1 / yScale).toFixed(5);
-
-    animation.push(`
-      ${percentage}% {
-        transform: scale3d(${xScale}, ${yScale}, 1);
-      }`);
-
-    inverseAnimation.push(`
-      ${percentage}% {
-        transform: scale3d(${invScaleX}, ${invScaleY}, 1);
-      }`);
-  }
-
-  return {
-    animation: keyframes(animation),
-    inverseAnimation: keyframes(inverseAnimation),
-  };
-};
+export interface ScaleProps extends CollectorChildrenProps, MotionProps {
+  /**
+   * Origin of the transform. Defaults to "top left".
+   */
+  transformOrigin?: string;
+}
 
 export const INVERSE_SCALE_CLASS_NAME = 'inVRsE-sCle';
 
@@ -60,23 +25,24 @@ const Scale: React.FC<ScaleProps> = ({
   children,
   duration = 'dynamic',
   timingFunction = standard(),
+  transformOrigin = 'top left',
 }: ScaleProps) => {
   let calculatedDuration: number;
-  let animation: string;
-  let inverseAnimation: string;
 
   return (
     <Collector
       data={{
         action: CollectorActions.motion,
         payload: {
-          beforeAnimate: (elements, onFinish, setChildProps) => {
+          beforeAnimate: (elements, onFinish, setChildProps, { animationName }) => {
             const originBoundingBox = elements.origin.elementBoundingBox;
             const destinationBoundingBox = elements.destination.elementBoundingBox;
             const scaleToX = originBoundingBox.size.width / destinationBoundingBox.size.width;
             const scaleToY = originBoundingBox.size.height / destinationBoundingBox.size.height;
             const inverseScaleToX = 1 / scaleToX;
             const inverseScaleToY = 1 / scaleToY;
+            const endX = 1;
+            const endY = 1;
 
             calculatedDuration =
               duration === 'dynamic'
@@ -86,15 +52,24 @@ const Scale: React.FC<ScaleProps> = ({
                   )
                 : duration;
 
-            ({ animation, inverseAnimation } = buildKeyframes(
-              elements,
+            const { animation, inverseAnimation } = buildKeyframes(
               calculatedDuration,
               timingFunction
-            ));
+            )(step => {
+              const xScale = Number((scaleToX + (endX - scaleToX) * step).toFixed(5));
+              const yScale = Number((scaleToY + (endY - scaleToY) * step).toFixed(5));
+              const invScaleX = (1 / xScale).toFixed(5);
+              const invScaleY = (1 / yScale).toFixed(5);
+              return [
+                'transform',
+                `scale3d(${xScale}, ${yScale}, 1)`,
+                `scale3d(${invScaleX}, ${invScaleY}, 1)`,
+              ];
+            });
 
             const common = {
+              transformOrigin,
               willChange: 'transform',
-              transformOrigin: 'top left',
               animationTimingFunction: 'step-end',
               animationFillMode: 'forwards',
               animationPlayState: 'paused',
@@ -106,7 +81,14 @@ const Scale: React.FC<ScaleProps> = ({
                 ...common,
                 transform: combine(`scale3d(${scaleToX}, ${scaleToY}, 1)`, '')(prevStyle.transform),
                 animationDuration: `${calculatedDuration}ms`,
-                animationName: combine(animation)(prevStyle.animationName),
+                animationName: combine(animationName('transform'))(prevStyle.animationName),
+              }),
+              keyframes: getPrevKeyframes => ({
+                transform: composeKeyframes(getPrevKeyframes('transform'), animation),
+                inverseTransform: composeKeyframes(
+                  getPrevKeyframes('inverseTransform'),
+                  inverseAnimation
+                ),
               }),
               className: () =>
                 css({
@@ -114,7 +96,7 @@ const Scale: React.FC<ScaleProps> = ({
                     ...common,
                     transform: `scale3d(${inverseScaleToX}, ${inverseScaleToY}, 1)`,
                     animationDuration: `${calculatedDuration}ms`,
-                    animationName: inverseAnimation,
+                    animationName: animationName('inverseTransform'),
                   },
                 }),
             });

--- a/packages/motions/src/Scale/stories.tsx
+++ b/packages/motions/src/Scale/stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import styled from 'styled-components';
+import Translate from '../Translate';
 import { Toggler } from '@element-motion/dev';
 import { Motion } from '@element-motion/utils';
 import Scale from './index';
@@ -44,33 +45,176 @@ const MenuItem = styled.li`
   white-space: nowrap;
 `;
 
-storiesOf('@element-motion/motions/Scale', module).add('Default', () => (
-  <Toggler>
-    {toggler => (
-      <Motion triggerSelfKey={toggler.shown}>
-        <Scale duration={200}>
-          {motion => (
-            <Menu {...motion} isExpanded={toggler.shown} overflow="hidden">
-              <InverseScale>
-                {inverse => (
-                  <div {...inverse}>
-                    <MenuButton onClick={toggler.toggle}>Menu</MenuButton>
-                    <MenuItems
-                      className="target"
-                      style={{ position: toggler.shown ? 'static' : 'absolute' }}
-                    >
-                      <MenuItem>Menu item 1</MenuItem>
-                      <MenuItem>Menu item 2</MenuItem>
-                      <MenuItem>Menu item 3</MenuItem>
-                      <MenuItem>Menu item 4</MenuItem>
-                    </MenuItems>
-                  </div>
-                )}
-              </InverseScale>
-            </Menu>
-          )}
-        </Scale>
-      </Motion>
-    )}
-  </Toggler>
-));
+const origin = {
+  topLeft: 'top:0;left: 0;',
+  topRight: 'top:0;right:0;',
+  bottomRight: 'bottom:0;right:0;',
+  bottomLeft: 'bottom:0;left:0;',
+  midLeft: 'top:0;left:50%;',
+};
+
+const Block = styled.div<any>`
+  position: absolute;
+  width: ${props => props.size || 100}px;
+  height: ${props => props.size || 100}px;
+  background-color: red;
+  ${props => origin[props.origin]};
+`;
+
+storiesOf('@element-motion/motions/Scale', module)
+  .add('Multiple', () => (
+    <Toggler>
+      {toggler => (
+        <>
+          <Motion triggerSelfKey={toggler.shown}>
+            <Scale>
+              {motion => (
+                <Block
+                  origin="topLeft"
+                  {...motion}
+                  onClick={() => toggler.toggle()}
+                  size={toggler.shown ? 200 : 100}
+                />
+              )}
+            </Scale>
+          </Motion>
+
+          <Motion triggerSelfKey={toggler.shown}>
+            <Scale>
+              {motion => (
+                <Block
+                  origin="midLeft"
+                  {...motion}
+                  onClick={() => toggler.toggle()}
+                  size={toggler.shown ? 300 : 100}
+                />
+              )}
+            </Scale>
+          </Motion>
+        </>
+      )}
+    </Toggler>
+  ))
+
+  .add('OriginTopLeft', () => (
+    <Toggler>
+      {toggler => (
+        <Motion triggerSelfKey={toggler.shown}>
+          <Scale>
+            {motion => (
+              <Block
+                origin="topLeft"
+                {...motion}
+                onClick={() => toggler.toggle()}
+                size={toggler.shown ? 300 : 100}
+              />
+            )}
+          </Scale>
+        </Motion>
+      )}
+    </Toggler>
+  ))
+  .add('ComposedWithTranslate', () => (
+    <Toggler>
+      {toggler => (
+        <Motion triggerSelfKey={toggler.shown}>
+          <Translate>
+            <Scale>
+              {motion => (
+                <Block
+                  origin={toggler.shown ? 'topRight' : 'topLeft'}
+                  {...motion}
+                  onClick={() => toggler.toggle()}
+                  size={toggler.shown ? 300 : 100}
+                />
+              )}
+            </Scale>
+          </Translate>
+        </Motion>
+      )}
+    </Toggler>
+  ))
+  .add('OriginTopRight', () => (
+    <Toggler>
+      {toggler => (
+        <Motion triggerSelfKey={toggler.shown}>
+          <Scale transformOrigin="top right">
+            {motion => (
+              <Block
+                origin="topRight"
+                {...motion}
+                onClick={() => toggler.toggle()}
+                size={toggler.shown ? 300 : 100}
+              />
+            )}
+          </Scale>
+        </Motion>
+      )}
+    </Toggler>
+  ))
+  .add('OriginBottomRight', () => (
+    <Toggler>
+      {toggler => (
+        <Motion triggerSelfKey={toggler.shown}>
+          <Scale transformOrigin="bottom right">
+            {motion => (
+              <Block
+                origin="bottomRight"
+                {...motion}
+                onClick={() => toggler.toggle()}
+                size={toggler.shown ? 300 : 100}
+              />
+            )}
+          </Scale>
+        </Motion>
+      )}
+    </Toggler>
+  ))
+  .add('OriginBottomLeft', () => (
+    <Toggler>
+      {toggler => (
+        <Motion triggerSelfKey={toggler.shown}>
+          <Scale transformOrigin="bottom left">
+            {motion => (
+              <Block
+                origin="bottomLeft"
+                {...motion}
+                onClick={() => toggler.toggle()}
+                size={toggler.shown ? 300 : 100}
+              />
+            )}
+          </Scale>
+        </Motion>
+      )}
+    </Toggler>
+  ))
+  .add('WithInverse', () => (
+    <Toggler>
+      {toggler => (
+        <Motion triggerSelfKey={toggler.shown}>
+          <Scale duration={200}>
+            {motion => (
+              <Menu {...motion} isExpanded={toggler.shown} overflow="hidden">
+                <InverseScale>
+                  {inverse => (
+                    <div {...inverse}>
+                      <MenuButton onClick={toggler.toggle}>Menu</MenuButton>
+                      <MenuItems
+                        className="target"
+                        style={{ position: toggler.shown ? 'static' : 'absolute' }}
+                      >
+                        <MenuItem>Menu item 1</MenuItem>
+                        <MenuItem>Menu item 2</MenuItem>
+                        <MenuItem>Menu item 3</MenuItem>
+                        <MenuItem>Menu item 4</MenuItem>
+                      </MenuItems>
+                    </div>
+                  )}
+                </InverseScale>
+              </Menu>
+            )}
+          </Scale>
+        </Motion>
+      )}
+    </Toggler>
+  ));

--- a/packages/motions/src/Translate/index.tsx
+++ b/packages/motions/src/Translate/index.tsx
@@ -1,61 +1,19 @@
 import * as React from 'react';
-import { css, keyframes, cx } from 'emotion';
+import { css, cx } from 'emotion';
 import {
   Collector,
   CollectorChildrenProps,
   CollectorActions,
-  MotionData,
-  bezierToFunc,
   combine,
   standard,
+  keyframes,
   dynamic,
+  composeKeyframes,
   recalculateElementBoundingBoxFromScroll,
 } from '@element-motion/utils';
 import { MotionProps } from '../types';
 
 export interface TranslateProps extends CollectorChildrenProps, MotionProps {}
-
-const buildKeyframes = (elements: MotionData, duration: number, bezierCurve: string) => {
-  const frameTime = 1000 / 60;
-  const nFrames = Math.round(duration / frameTime);
-  const percentIncrement = 100 / nFrames;
-  const originBoundingBox = recalculateElementBoundingBoxFromScroll(
-    elements.origin.elementBoundingBox
-  );
-  const destinationBoundingBox = elements.destination.elementBoundingBox;
-  const timingFunction = bezierToFunc(bezierCurve, duration);
-
-  const startX = originBoundingBox.location.left - destinationBoundingBox.location.left;
-  const startY = originBoundingBox.location.top - destinationBoundingBox.location.top;
-  const endX = 0;
-  const endY = 0;
-  const animation: string[] = [];
-  const inverseAnimation: string[] = [];
-
-  for (let i = 0; i <= nFrames; i += 1) {
-    const step = Number(timingFunction(i / nFrames).toFixed(5));
-    const percentage = Number((i * percentIncrement).toFixed(5));
-    const translateToX = Number((startX + (endX - startX) * step).toFixed(5));
-    const translateToY = Number((startY + (endY - startY) * step).toFixed(5));
-    const inverseTranslateToX = -translateToX;
-    const inverseTranslateToY = -translateToY;
-
-    animation.push(`
-      ${percentage}% {
-        transform: translate3d(${translateToX}px, ${translateToY}px, 0);
-      }`);
-
-    inverseAnimation.push(`
-      ${percentage}% {
-        transform: translate3d(${inverseTranslateToX}px, ${inverseTranslateToY}px, 0);
-      }`);
-  }
-
-  return {
-    animation: keyframes(animation),
-    inverseAnimation: keyframes(inverseAnimation),
-  };
-};
 
 export const INVERSE_TRANSLATE_CLASS_NAME = 'inVRsE-tRnsFrm';
 
@@ -65,25 +23,23 @@ const Translate: React.FC<TranslateProps> = ({
   timingFunction = standard(),
 }: TranslateProps) => {
   let calculatedDuration: number;
-  let animation: string;
-  let inverseAnimation: string;
 
   return (
     <Collector
       data={{
         action: CollectorActions.motion,
         payload: {
-          beforeAnimate: (elements, onFinish, setChildProps) => {
+          beforeAnimate: (elements, onFinish, setChildProps, { animationName }) => {
             const originBoundingBox = recalculateElementBoundingBoxFromScroll(
               elements.origin.elementBoundingBox
             );
             const destinationBoundingBox = elements.destination.elementBoundingBox;
-            const translateToX =
-              originBoundingBox.location.left - destinationBoundingBox.location.left;
-            const translateToY =
-              originBoundingBox.location.top - destinationBoundingBox.location.top;
-            const inverseTranslateToX = -translateToX;
-            const inverseTranslateToY = -translateToY;
+            const startX = originBoundingBox.location.left - destinationBoundingBox.location.left;
+            const startY = originBoundingBox.location.top - destinationBoundingBox.location.top;
+            const startInverseX = -startX;
+            const startInverseY = -startY;
+            const endX = 0;
+            const endY = 0;
 
             calculatedDuration =
               duration === 'dynamic'
@@ -93,11 +49,19 @@ const Translate: React.FC<TranslateProps> = ({
                   )
                 : duration;
 
-            ({ animation, inverseAnimation } = buildKeyframes(
-              elements,
-              calculatedDuration,
-              timingFunction
-            ));
+            const { animation, inverseAnimation } = keyframes(calculatedDuration, timingFunction)(
+              step => {
+                const translateToX = Number((startX + (endX - startX) * step).toFixed(5));
+                const translateToY = Number((startY + (endY - startY) * step).toFixed(5));
+                const inverseTranslateToX = -translateToX;
+                const inverseTranslateToY = -translateToY;
+                return [
+                  'transform',
+                  `translate3d(${translateToX}px, ${translateToY}px, 0)`,
+                  `translate3d(${inverseTranslateToX}px, ${inverseTranslateToY}px, 0)`,
+                ];
+              }
+            );
 
             const common = {
               willChange: 'transform',
@@ -111,19 +75,26 @@ const Translate: React.FC<TranslateProps> = ({
               style: prevStyle => ({
                 ...prevStyle,
                 ...common,
-                transform: combine(`translate3d(${translateToX}px, ${translateToY}px, 0)`, '')(
+                transform: combine(`translate3d(${startX}px, ${startY}px, 0)`, '')(
                   prevStyle.transform
                 ),
                 animationDuration: `${calculatedDuration}ms`,
-                animationName: combine(animation)(prevStyle.animationName),
+                animationName: combine(animationName('transform'))(prevStyle.animationName),
+              }),
+              keyframes: getPrevKeyframes => ({
+                transform: composeKeyframes(getPrevKeyframes('transform'), animation),
+                inverseTransform: composeKeyframes(
+                  getPrevKeyframes('inverseTransform'),
+                  inverseAnimation
+                ),
               }),
               className: () =>
                 css({
                   [`.${INVERSE_TRANSLATE_CLASS_NAME}`]: {
                     ...common,
-                    transform: `translate3d(${inverseTranslateToX}px, ${inverseTranslateToY}px, 0)`,
+                    transform: `translate3d(${startInverseX}px, ${startInverseY}px, 0)`,
                     animationDuration: `${calculatedDuration}ms`,
-                    animationName: inverseAnimation,
+                    animationName: animationName('inverseTransform'),
                   },
                 }),
             });

--- a/packages/utils/.size-limit.js
+++ b/packages/utils/.size-limit.js
@@ -1,10 +1,10 @@
 module.exports = [
   {
-    limit: '3.95 KB',
+    limit: '4.43 KB',
     path: 'dist/esm/index.js',
   },
   {
-    limit: '3 KB',
+    limit: '3.16 KB',
     path: 'dist/esm/Motion/index.js',
   },
   {

--- a/packages/utils/src/Collector/index.tsx
+++ b/packages/utils/src/Collector/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ElementBoundingBox } from '../lib/dom';
+import { KeyframeDefinition } from '../lib/keyframes';
 
 export type InlineStyles = React.CSSProperties;
 
@@ -8,9 +9,14 @@ export interface TargetProps {
   className?: string;
 }
 
+export interface Keyframes {
+  [name: string]: KeyframeDefinition;
+}
+
 export interface TargetPropsFunc {
   style?: (previous: InlineStyles) => InlineStyles | undefined;
   className?: (previous: string | undefined) => string | undefined;
+  keyframes?: (getPrevKeyframes: (name: string) => KeyframeDefinition) => Keyframes;
 }
 
 export type setChildProps = (props: TargetPropsFunc) => void;
@@ -25,7 +31,8 @@ export type setChildProps = (props: TargetPropsFunc) => void;
 export type MotionCallback = (
   elements: MotionData,
   onFinish: () => void,
-  setChildProps: setChildProps
+  setChildProps: setChildProps,
+  extra: { animationName: (name: string) => string }
 ) => React.ReactNode | undefined | void;
 
 export enum CollectorActions {

--- a/packages/utils/src/Motion/types.tsx
+++ b/packages/utils/src/Motion/types.tsx
@@ -1,4 +1,4 @@
-import { CollectorChildrenProps, InlineStyles } from '../Collector';
+import { CollectorChildrenProps, InlineStyles, Keyframes } from '../Collector';
 import { InjectedProps } from '../VisibilityManager';
 
 export type MotionFunc = () => Promise<void>;
@@ -15,6 +15,7 @@ export type MotionBlock = MappedMotion[];
 export interface ChildProps {
   style?: InlineStyles;
   className?: string;
+  keyframes?: Keyframes;
 }
 
 export interface MotionState {

--- a/packages/utils/src/VisibilityManager/stories.tsx
+++ b/packages/utils/src/VisibilityManager/stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import { storiesOf } from '@storybook/react';
-import BodyClassName from 'react-body-classname';
+// @ts-ignore
+import * as BodyClassName from 'react-body-classname';
 import { Toggler } from '@element-motion/dev';
 import { WrappedVisibilityManager as VisibilityManager } from './index';
 import { WrappedMotion as Motion } from '../Motion';

--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -10,5 +10,6 @@ export * from './lib/math';
 export * from './lib/duration';
 export * from './lib/style';
 export * from './lib/stylesheet';
+export * from './lib/keyframes';
 export * from './lib/log';
 export { default as noop } from './lib/noop';

--- a/packages/utils/src/lib/__tests__/keyframes.test.tsx
+++ b/packages/utils/src/lib/__tests__/keyframes.test.tsx
@@ -1,0 +1,18 @@
+import { composeKeyframes, KeyframeDefinition } from '../keyframes';
+
+describe('@element-motion/utils/keyframes', () => {
+  it('should compose keyframes with prev in the first position', () => {
+    const prev: KeyframeDefinition = {
+      0: ['transform', 'scale(1)'],
+    };
+    const next: KeyframeDefinition = {
+      0: ['transform', 'translateX(100px)'],
+    };
+
+    const composed = composeKeyframes(prev, next);
+
+    expect(composed).toEqual({
+      0: ['transform', 'scale(1) translateX(100px)'],
+    });
+  });
+});

--- a/packages/utils/src/lib/dom.tsx
+++ b/packages/utils/src/lib/dom.tsx
@@ -58,6 +58,7 @@ export function getElementBoundingBox(
       height: options.useOffsetSize ? element.offsetHeight : rect.height,
     },
     location: {
+      // Will return the true distance from the top of the page (viewport + scroll)
       left: rect.left + scrollLeft,
       top: rect.top + scrollTop,
     },
@@ -90,6 +91,11 @@ export function calculateWindowCentre() {
   };
 }
 
+/**
+ * Used to pad the location with an updated scroll position.
+ * This is used because the destination and origin elements are calculated in the same frame
+ * but the scroll could have changed just after the origin has changed but before the destintation.
+ */
 export function recalculateElementBoundingBoxFromScroll(
   elementBoundingBox: ElementBoundingBox
 ): ElementBoundingBox {

--- a/packages/utils/src/lib/keyframes.tsx
+++ b/packages/utils/src/lib/keyframes.tsx
@@ -1,0 +1,63 @@
+import { bezierToFunc } from './curves';
+
+/**
+ * Key is the percentage.
+ * First element is the property name.
+ * Second element is the property value.
+ */
+export interface KeyframeDefinition {
+  // TODO: This is currently only allowing one property per property.
+  // e.g: transform: scale(1);
+  // We should change it to support any amount of properties.
+  [key: number]: [string, string];
+}
+
+export const keyframes = (duration: number, bezierCurve: string) => {
+  const frameTime = 1000 / 60;
+  const nFrames = Math.round(duration / frameTime);
+  const percentIncrement = 100 / nFrames;
+  const timingFunction = bezierToFunc(bezierCurve, duration);
+
+  return (callback: (step: number) => [string, string, string]) => {
+    const animation = {};
+    const inverseAnimation = {};
+
+    for (let i = 0; i <= nFrames; i += 1) {
+      const step = Number(timingFunction(i / nFrames).toFixed(5));
+      const percentage = Number((i * percentIncrement).toFixed(5));
+      const [property, animationKeyframe, animationInverseKeyframe] = callback(step);
+      animation[percentage] = [property, animationKeyframe];
+      inverseAnimation[percentage] = [property, animationInverseKeyframe];
+    }
+
+    return { animation, inverseAnimation };
+  };
+};
+
+/**
+ * Will compose keyframe percentages together.
+ */
+export const composeKeyframes = (
+  prev: KeyframeDefinition | undefined,
+  next: KeyframeDefinition,
+  delimeter: string = ' '
+): KeyframeDefinition => {
+  if (!prev) {
+    return next;
+  }
+
+  const composed: KeyframeDefinition = {
+    ...prev,
+  };
+
+  Object.keys(next).forEach(key => {
+    const [prevProperty, prevValue] = composed[key];
+    const [nextProperty, nextValue] = next[key];
+
+    if (prevProperty === nextProperty) {
+      composed[key] = [prevProperty, `${prevValue}${delimeter}${nextValue}`];
+    }
+  });
+
+  return composed;
+};

--- a/packages/utils/src/lib/stylesheet.tsx
+++ b/packages/utils/src/lib/stylesheet.tsx
@@ -1,10 +1,15 @@
+let id = 0;
+
 export const createManager = () => {
+  id += 1;
   const sheets: HTMLStyleElement[] = [];
 
   return {
+    id,
     css: (sheet: string, className?: string) => {
       const element = document.createElement('style');
-      element.innerText = sheet;
+      element.setAttribute('data-element-motion', `css-manager-${id}`);
+      element.innerHTML = sheet;
       sheets.push(element);
       document.head.appendChild(element);
       return className;
@@ -15,3 +20,5 @@ export const createManager = () => {
     },
   };
 };
+
+export type StyleSheetManager = ReturnType<typeof createManager>;


### PR DESCRIPTION
This will enable composing keyframes together between motion components.

Mainly if one motion has defined  keyframes with `transform: scale(..)` and another with `transform: translate3d(...)` we can compose them to `transform: scale(...) translate3d(...)`

Preconditions: 
- Each motion needs to use the same duration
- Each motion keyframes should be calculated by the same util

---

Introduces a new argument in Motion component phases to get the (namespaced) animation name.

```diff
const animate = (
  elements,
  onFinish,
  setChildProps,
+  { animationName }
) => {
  setChildProps({
    style: prevStyle => ({
-      animationName: combine('transform')(prevStyle.animationName),
+      animationName: combine(animationName('transform'))(prevStyle.animationName),
    }),
  });
}
```

When creating your own keyframes you may want to use `keyframes` from `@element-motion/utils`, currently it only supports a single property to animate.

```js
import { keyframes } from '@element-motion/utils';

const { animation, inverseAnimation } = keyframes(
  calculatedDuration,
  timingFunction
)(step => {
  const xScale = Number((scaleToX + (endX - scaleToX) * step).toFixed(5));
  const yScale = Number((scaleToY + (endY - scaleToY) * step).toFixed(5));
  const invScaleX = (1 / xScale).toFixed(5);
  const invScaleY = (1 / yScale).toFixed(5);
  return [
    'transform', // property we're animating
    `scale3d(${xScale}, ${yScale}, 1)`, // primary animation
    `scale3d(${invScaleX}, ${invScaleY}, 1)`, // inverse of the animation - if appropriate
  ];
});
```